### PR TITLE
Update to 0.18.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "peft" %}
-{% set version = "0.5.0" %}
+{% set version = "0.18.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,12 @@ package:
 
 source:
   url: https://github.com/huggingface/peft/archive/v{{ version }}.tar.gz
-  sha256: 954b86dcf3dad64562ce7b9167485ac42c47fcc668d82ea99874001aa585f53e
+  sha256: 15f17cef72fd1091ae57045b1ec54c3123ae8c83128614b202f4920f86582078
 
 build:
-  skip: True  # [s390x or ppc64le]
+  skip: True  # [s390x or ppc64le or py<310]
   number: 0
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation . -vv
-
 
 requirements:
   host:
@@ -23,32 +22,24 @@ requirements:
     - setuptools
   run:
     - python
+    - accelerate >=0.21.0
+    - huggingface_hub >=0.25.0
     - numpy >=1.17
     - packaging >=20.0
     - psutil
-    - pyyaml
     - pytorch >=1.13.0
+    - pyyaml
+    - safetensors
     - transformers
     - tqdm
-    - huggingface_accelerate >=0.21.0
-    - safetensors
 
 test:
-  source_files:
-    - tests
   imports:
     - peft
   commands:
     - pip check
-    # skip test_prompt_encoder_warning_num_layers, see https://github.com/huggingface/peft/issues/1066
-    - pytest -v tests -k "not test_prompt_encoder_warning_num_layers"
   requires:
     - pip
-    - parameterized
-    - datasets
-    - diffusers <0.21.0
-    - pytest
-    - pytest-xdist
 
 about:
   home: https://github.com/huggingface/peft
@@ -57,11 +48,11 @@ about:
   license_family: Apache
   dev_url: https://github.com/huggingface/peft
   doc_url: https://huggingface.co/docs/peft/index
-  summary: state of the art parameter efficient fine tuning peft methods
-  description: | 
+  summary: Parameter-Efficient Fine-Tuning (PEFT)
+  description: |
     Parameter-Efficient Fine-Tuning (PEFT) methods enable efficient adaptation of pre-trained language models (PLMs) to various
-    downstream applications without fine-tuning all the model's parameters. Fine-tuning large-scale PLMs is often prohibitively costly. 
-    In this regard, PEFT methods only fine-tune a small number of (extra) model parameters, thereby greatly decreasing the computational 
+    downstream applications without fine-tuning all the model's parameters. Fine-tuning large-scale PLMs is often prohibitively costly.
+    In this regard, PEFT methods only fine-tune a small number of (extra) model parameters, thereby greatly decreasing the computational
     and storage costs. Recent State-of-the-Art PEFT techniques achieve performance comparable to that of full fine-tuning.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,12 +34,17 @@ requirements:
     - tqdm
 
 test:
+  source_files:
+    - tests
   imports:
     - peft
   commands:
     - pip check
+    - pytest -v tests/test_config.py tests/test_mapping.py tests/test_bufferdict.py -k "not pretrained and not remote"
   requires:
     - pip
+    - pytest
+    - parameterized
 
 about:
   home: https://github.com/huggingface/peft

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools
   run:
     - python
-    - accelerate >=0.21.0
+    - huggingface_accelerate >=0.21.0
     - huggingface_hub >=0.25.0
     - numpy >=1.17
     - packaging >=20.0
@@ -30,7 +30,7 @@ requirements:
     - pytorch >=1.13.0
     - pyyaml
     - safetensors
-    - transformers
+    - transformers >=4.36.0
     - tqdm
 
 test:


### PR DESCRIPTION
peft 0.18.1                                                                                             
                                                                                                                                                
**Destination channel:** defaults                                                                                                             
                                                                                                                                                
  ### Links                                                                                                                                     
                                                                                                                                                
  - [PKG-11399](https://anaconda.atlassian.net/browse/PKG-11399)
  - [Upstream repository](https://github.com/huggingface/peft)
  - [Upstream changelog/diff](https://github.com/huggingface/peft/compare/v0.5.0...v0.18.1)

  ### Explanation of changes:
   - Version bump from 0.5.0 to 0.18.1
   - Add `py<310` skip (upstream requires Python >=3.10)
   - Add `huggingface_hub >=0.25.0` (new required dependency)
   - Add `transformers >=4.36.0` (peft imports `Cache`/`DynamicCache` from `cache_utils.py`, introduced in 4.36.0)
   - Simplify test section to import + pip check (removed outdated test deps like `diffusers <0.21.0`)

[PKG-11399]: https://anaconda.atlassian.net/browse/PKG-11399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ